### PR TITLE
feat: add API proxy server

### DIFF
--- a/docs/qwen-usage.md
+++ b/docs/qwen-usage.md
@@ -1,0 +1,23 @@
+# Qwen Usage Accounting
+
+Qwen reports usage with every API response. The `usage` field contains the token counts for the request and the model's reply:
+
+```json
+{
+  "usage": {
+    "prompt_tokens": 15,
+    "completion_tokens": 30,
+    "total_tokens": 45
+  }
+}
+```
+
+Both the prompt and the completion tokens contribute to your interaction quota. Each API call counts once regardless of response size.
+
+## Reducing Interaction Costs
+- **Trim prompts** – remove unnecessary context before sending a request.
+- **Set `max_tokens`** – cap the length of model outputs to avoid large completions.
+- **Batch messages** – combine related questions into a single request when possible.
+- **Reuse conversations** – carry forward previous responses instead of repeating information.
+
+Monitoring these counts helps avoid wasting interactions and keeps usage within the allotted limits.

--- a/packages/api-proxy/README.md
+++ b/packages/api-proxy/README.md
@@ -1,0 +1,36 @@
+# API Proxy
+
+A standalone HTTP server that reuses Qwen OAuth credentials to expose the Qwen API using familiar OpenAI and Anthropic formats.
+
+## Authentication
+
+The proxy reads the OAuth token produced by the Qwen Code CLI. After logging in with the CLI, credentials are stored in `~/.qwen/oauth_creds.json` and automatically refreshed when needed.
+
+## Usage
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Start the server**
+   ```bash
+   cd packages/api-proxy
+   npm start
+   ```
+3. **Call the endpoints**
+   - OpenAI-compatible:
+     ```bash
+     curl http://localhost:3000/v1/completions -H 'Content-Type: application/json' \
+       -d '{"model":"qwen-max","prompt":"hi"}'
+     ```
+   - Anthropic-compatible:
+     ```bash
+     curl http://localhost:3000/v1/messages -H 'Content-Type: application/json' \
+       -d '{"model":"qwen-max","messages":[{"role":"user","content":"hi"}]}'
+     ```
+
+Model metadata is available at `/v1/models` and `/v1/models/{id}`.
+
+## Notes
+- The proxy runs independently from the main Qwen Code application.
+- It simply forwards requests using the stored OAuth token; no API keys are required.

--- a/packages/api-proxy/package.json
+++ b/packages/api-proxy/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@qwen-code/api-proxy",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "tsx src/server.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@qwen-code/qwen-code-core": "workspace:*"
+  }
+}

--- a/packages/api-proxy/src/anthropic.ts
+++ b/packages/api-proxy/src/anthropic.ts
@@ -1,0 +1,38 @@
+export interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AnthropicRequest {
+  model: string;
+  max_tokens?: number;
+  messages: AnthropicMessage[];
+}
+
+/** Convert an Anthropic messages request to OpenAI chat completion format */
+export function anthropicToOpenAI(req: AnthropicRequest): any {
+  return {
+    model: req.model,
+    max_tokens: req.max_tokens,
+    messages: req.messages.map((m) => ({ role: m.role, content: m.content })),
+  };
+}
+
+/** Convert an OpenAI chat completion response to Anthropic message format */
+export function openAIToAnthropic(resp: any): any {
+  const text = resp?.choices?.[0]?.message?.content ?? '';
+  const usage = resp?.usage
+    ? {
+        input_tokens: resp.usage.prompt_tokens,
+        output_tokens: resp.usage.completion_tokens,
+      }
+    : undefined;
+  return {
+    id: resp.id,
+    type: 'message',
+    role: 'assistant',
+    model: resp.model,
+    content: [{ type: 'text', text }],
+    usage,
+  };
+}

--- a/packages/api-proxy/src/server.ts
+++ b/packages/api-proxy/src/server.ts
@@ -1,0 +1,107 @@
+import http from 'node:http';
+import { URL } from 'node:url';
+import { QwenOAuth2Client } from '@qwen-code/qwen-code-core/qwen/qwenOAuth2.js';
+import { SharedTokenManager } from '@qwen-code/qwen-code-core/qwen/sharedTokenManager.js';
+import { anthropicToOpenAI, openAIToAnthropic } from './anthropic.js';
+
+const client = new QwenOAuth2Client();
+const manager = SharedTokenManager.getInstance();
+const DEFAULT_ENDPOINT = 'https://dashscope.aliyuncs.com/compatible-mode/v1';
+
+async function getAuth() {
+  const creds = await manager.getValidCredentials(client);
+  if (!creds.access_token) throw new Error('No access token');
+  const endpoint = creds.resource_url || DEFAULT_ENDPOINT;
+  return { token: creds.access_token, endpoint };
+}
+
+function readBody(req: http.IncomingMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => (data += chunk));
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse) {
+  const url = new URL(req.url || '/', 'http://localhost');
+  try {
+    if (req.method === 'POST' && url.pathname === '/v1/completions') {
+      const body = await readBody(req);
+      const { token, endpoint } = await getAuth();
+      const apiResp = await fetch(`${endpoint}${url.pathname}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      const data = await apiResp.json();
+      res.writeHead(apiResp.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+      return;
+    }
+    if (req.method === 'POST' && url.pathname === '/v1/messages') {
+      const body = anthropicToOpenAI(await readBody(req));
+      const { token, endpoint } = await getAuth();
+      const apiResp = await fetch(`${endpoint}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      const data = openAIToAnthropic(await apiResp.json());
+      res.writeHead(apiResp.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+      return;
+    }
+    if (req.method === 'GET' && url.pathname === '/v1/models') {
+      const { token, endpoint } = await getAuth();
+      const apiResp = await fetch(`${endpoint}/models`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await apiResp.json();
+      res.writeHead(apiResp.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+      return;
+    }
+    if (req.method === 'GET' && url.pathname.startsWith('/v1/models/')) {
+      const model = url.pathname.split('/').pop();
+      const { token, endpoint } = await getAuth();
+      const apiResp = await fetch(`${endpoint}/models/${model}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await apiResp.json();
+      res.writeHead(apiResp.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: (err as Error).message }));
+  }
+}
+
+export function start(port = 3000) {
+  const server = http.createServer(handleRequest);
+  server.listen(port, () => {
+    console.log(`API proxy listening on port ${port}`);
+  });
+  return server;
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  start();
+}

--- a/packages/api-proxy/test/anthropic.test.ts
+++ b/packages/api-proxy/test/anthropic.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { anthropicToOpenAI, openAIToAnthropic } from '../src/anthropic.js';
+
+describe('anthropic conversions', () => {
+  it('converts anthropic request to openai format', () => {
+    const req = {
+      model: 'qwen',
+      max_tokens: 10,
+      messages: [{ role: 'user', content: 'hi' }],
+    };
+    const converted = anthropicToOpenAI(req);
+    expect(converted).toEqual({
+      model: 'qwen',
+      max_tokens: 10,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+  });
+
+  it('converts openai response to anthropic format', () => {
+    const resp = {
+      id: '1',
+      model: 'qwen',
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 2 },
+    };
+    const converted = openAIToAnthropic(resp);
+    expect(converted.content[0].text).toBe('hello');
+    expect(converted.usage).toEqual({ input_tokens: 1, output_tokens: 2 });
+  });
+});

--- a/packages/api-proxy/test/server.test.ts
+++ b/packages/api-proxy/test/server.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { AddressInfo } from 'node:net';
+
+// Preserve the real fetch for making requests to our local server
+const realFetch = globalThis.fetch;
+const upstreamFetch = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', (url: any, init?: any) => {
+  if (typeof url === 'string' && url.startsWith('http://localhost')) {
+    return realFetch(url, init);
+  }
+  return upstreamFetch(url, init);
+});
+
+const getCreds = vi.hoisted(() => vi.fn());
+vi.mock('@qwen-code/qwen-code-core/qwen/qwenOAuth2.js', () => ({
+  QwenOAuth2Client: vi.fn().mockImplementation(() => ({})),
+}));
+vi.mock('@qwen-code/qwen-code-core/qwen/sharedTokenManager.js', () => ({
+  SharedTokenManager: { getInstance: () => ({ getValidCredentials: getCreds }) },
+}));
+
+import { start } from '../src/server.js';
+import type http from 'node:http';
+
+describe('api proxy server', () => {
+  let server: http.Server;
+
+  beforeEach(() => {
+    upstreamFetch.mockReset();
+    getCreds.mockReset();
+  });
+
+  afterEach(() => {
+    server?.close();
+  });
+
+  it('proxies completions with auth header', async () => {
+    getCreds.mockResolvedValue({ access_token: 't', resource_url: 'https://upstream' });
+    upstreamFetch.mockResolvedValue({ status: 200, json: async () => ({ ok: true }) });
+    server = start(0);
+    const port = (server.address() as AddressInfo).port;
+
+    const resp = await realFetch(`http://localhost:${port}/v1/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'qwen', prompt: 'hi' }),
+    });
+
+    expect(await resp.json()).toEqual({ ok: true });
+    expect(upstreamFetch).toHaveBeenCalledWith(
+      'https://upstream/v1/completions',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer t' }),
+      }),
+    );
+  });
+
+  it('returns 500 on invalid JSON', async () => {
+    getCreds.mockResolvedValue({ access_token: 't', resource_url: 'https://upstream' });
+    server = start(0);
+    const port = (server.address() as AddressInfo).port;
+
+    const resp = await realFetch(`http://localhost:${port}/v1/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    });
+
+    expect(resp.status).toBe(500);
+    const body = await resp.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  it('forwards upstream error status', async () => {
+    getCreds.mockResolvedValue({ access_token: 't', resource_url: 'https://upstream' });
+    upstreamFetch.mockResolvedValue({ status: 401, json: async () => ({ error: 'unauthorized' }) });
+    server = start(0);
+    const port = (server.address() as AddressInfo).port;
+
+    const resp = await realFetch(`http://localhost:${port}/v1/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'qwen', prompt: 'hi' }),
+    });
+
+    expect(resp.status).toBe(401);
+    expect(await resp.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  it('responds with 500 when auth missing', async () => {
+    getCreds.mockResolvedValue({});
+    server = start(0);
+    const port = (server.address() as AddressInfo).port;
+
+    const resp = await realFetch(`http://localhost:${port}/v1/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'qwen', prompt: 'hi' }),
+    });
+
+    expect(resp.status).toBe(500);
+    const body = await resp.json();
+    expect(body.error).toContain('No access token');
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api-proxy/tsconfig.json
+++ b/packages/api-proxy/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/qwenfastapi/anthropic.py
+++ b/qwenfastapi/anthropic.py
@@ -1,0 +1,42 @@
+from typing import Any, Dict, List
+
+# Define types for clarity
+AnthropicMessage = Dict[str, str]
+AnthropicRequest = Dict[str, Any]
+
+
+def anthropic_to_openai(req: AnthropicRequest) -> Dict[str, Any]:
+    """Convert an Anthropic-style messages request to OpenAI chat format."""
+    return {
+        "model": req.get("model"),
+        "max_tokens": req.get("max_tokens"),
+        "messages": [
+            {"role": m.get("role"), "content": m.get("content")}
+            for m in req.get("messages", [])
+        ],
+    }
+
+
+def openai_to_anthropic(resp: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert an OpenAI chat completion response to Anthropic message format."""
+    message = resp.get("choices", [{}])[0].get("message", {})
+    text = message.get("content", "")
+    usage = resp.get("usage")
+    anth_usage = (
+        {
+            "input_tokens": usage.get("prompt_tokens"),
+            "output_tokens": usage.get("completion_tokens"),
+        }
+        if usage
+        else None
+    )
+    result = {
+        "id": resp.get("id"),
+        "type": "message",
+        "role": "assistant",
+        "model": resp.get("model"),
+        "content": [{"type": "text", "text": text}],
+    }
+    if anth_usage:
+        result["usage"] = anth_usage
+    return result

--- a/qwenfastapi/main.py
+++ b/qwenfastapi/main.py
@@ -55,6 +55,8 @@ async def messages(req: Request) -> Response:
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     upstream_resp = await forward("POST", f"{endpoint}/chat/completions", token, body)
+    if not upstream_resp.is_success:
+        return Response(content=upstream_resp.content, status_code=upstream_resp.status_code, media_type="application/json")
     data = openai_to_anthropic(upstream_resp.json())
     return Response(content=json.dumps(data), status_code=upstream_resp.status_code, media_type="application/json")
 

--- a/qwenfastapi/main.py
+++ b/qwenfastapi/main.py
@@ -1,0 +1,84 @@
+from fastapi import FastAPI, HTTPException, Request, Response
+import httpx
+import os
+import json
+from typing import Any
+from .anthropic import anthropic_to_openai, openai_to_anthropic
+
+DEFAULT_ENDPOINT = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+app = FastAPI()
+
+
+def get_credentials() -> tuple[str, str]:
+    """Read OAuth credentials from the standard qwen location."""
+    path = os.path.join(os.path.expanduser("~"), ".qwen", "oauth_creds.json")
+    with open(path) as f:
+        data = json.load(f)
+    token = data.get("access_token")
+    if not token:
+        raise ValueError("No access token")
+    endpoint = data.get("resource_url") or DEFAULT_ENDPOINT
+    return token, endpoint
+
+
+async def forward(method: str, url: str, token: str, json_body: Any | None = None) -> httpx.Response:
+    headers = {"Authorization": f"Bearer {token}"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.request(method, url, json=json_body, headers=headers)
+    return resp
+
+
+@app.post("/v1/completions")
+async def completions(req: Request) -> Response:
+    try:
+        body = await req.json()
+    except Exception as e:  # JSON decode error
+        raise HTTPException(status_code=500, detail=str(e))
+    try:
+        token, endpoint = get_credentials()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    upstream_resp = await forward("POST", f"{endpoint}/v1/completions", token, body)
+    return Response(content=upstream_resp.content, status_code=upstream_resp.status_code, media_type="application/json")
+
+
+@app.post("/v1/messages")
+async def messages(req: Request) -> Response:
+    try:
+        original = await req.json()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    try:
+        body = anthropic_to_openai(original)
+        token, endpoint = get_credentials()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    upstream_resp = await forward("POST", f"{endpoint}/chat/completions", token, body)
+    data = openai_to_anthropic(upstream_resp.json())
+    return Response(content=json.dumps(data), status_code=upstream_resp.status_code, media_type="application/json")
+
+
+@app.get("/v1/models")
+async def list_models() -> Response:
+    try:
+        token, endpoint = get_credentials()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    resp = await forward("GET", f"{endpoint}/models", token)
+    return Response(content=resp.content, status_code=resp.status_code, media_type="application/json")
+
+
+@app.get("/v1/models/{model}")
+async def get_model(model: str) -> Response:
+    try:
+        token, endpoint = get_credentials()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    resp = await forward("GET", f"{endpoint}/models/{model}", token)
+    return Response(content=resp.content, status_code=resp.status_code, media_type="application/json")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=3000)

--- a/qwenfastapi/requirements.txt
+++ b/qwenfastapi/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+httpx
+respx
+pytest

--- a/qwenfastapi/tests/conftest.py
+++ b/qwenfastapi/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))

--- a/qwenfastapi/tests/test_anthropic.py
+++ b/qwenfastapi/tests/test_anthropic.py
@@ -1,0 +1,28 @@
+import pytest
+from qwenfastapi.anthropic import anthropic_to_openai, openai_to_anthropic
+
+
+def test_anthropic_to_openai():
+    req = {
+        "model": "qwen",
+        "max_tokens": 10,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    converted = anthropic_to_openai(req)
+    assert converted == {
+        "model": "qwen",
+        "max_tokens": 10,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def test_openai_to_anthropic():
+    resp = {
+        "id": "1",
+        "model": "qwen",
+        "choices": [{"message": {"content": "hello"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+    }
+    converted = openai_to_anthropic(resp)
+    assert converted["content"][0]["text"] == "hello"
+    assert converted["usage"] == {"input_tokens": 1, "output_tokens": 2}

--- a/qwenfastapi/tests/test_server.py
+++ b/qwenfastapi/tests/test_server.py
@@ -42,7 +42,9 @@ def test_forwards_upstream_error_status(client):
 
 
 def test_responds_500_when_auth_missing(monkeypatch):
-    monkeypatch.setattr(main, "get_credentials", lambda: (_ for _ in ()).throw(ValueError("No access token")))
+    def raise_no_access_token():
+        raise ValueError("No access token")
+    monkeypatch.setattr(main, "get_credentials", raise_no_access_token)
     client = TestClient(main.app)
     with respx.mock(assert_all_called=False):
         resp = client.post("/v1/completions", json={"model": "qwen", "prompt": "hi"})

--- a/qwenfastapi/tests/test_server.py
+++ b/qwenfastapi/tests/test_server.py
@@ -1,0 +1,91 @@
+import json
+from fastapi.testclient import TestClient
+import httpx
+import respx
+import pytest
+
+from qwenfastapi import main
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # default credentials
+    monkeypatch.setattr(main, "get_credentials", lambda: ("t", "https://upstream"))
+    return TestClient(main.app)
+
+
+def test_proxies_completions_with_auth_header(client):
+    with respx.mock(assert_all_called=True) as respx_mock:
+        route = respx_mock.post("https://upstream/v1/completions").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        resp = client.post("/v1/completions", json={"model": "qwen", "prompt": "hi"})
+        assert resp.json() == {"ok": True}
+        assert route.called
+        assert route.calls[0].request.headers["Authorization"] == "Bearer t"
+
+
+def test_returns_500_on_invalid_json(client):
+    resp = client.post("/v1/completions", data="not-json", headers={"Content-Type": "application/json"})
+    assert resp.status_code == 500
+    assert "detail" in resp.json()
+
+
+def test_forwards_upstream_error_status(client):
+    with respx.mock(assert_all_called=True) as respx_mock:
+        respx_mock.post("https://upstream/v1/completions").mock(
+            return_value=httpx.Response(401, json={"error": "unauthorized"})
+        )
+        resp = client.post("/v1/completions", json={"model": "qwen", "prompt": "hi"})
+        assert resp.status_code == 401
+        assert resp.json() == {"error": "unauthorized"}
+
+
+def test_responds_500_when_auth_missing(monkeypatch):
+    monkeypatch.setattr(main, "get_credentials", lambda: (_ for _ in ()).throw(ValueError("No access token")))
+    client = TestClient(main.app)
+    with respx.mock(assert_all_called=False):
+        resp = client.post("/v1/completions", json={"model": "qwen", "prompt": "hi"})
+        assert resp.status_code == 500
+
+
+def test_proxies_messages_and_converts_response(client):
+    with respx.mock(assert_all_called=True) as respx_mock:
+        def check_request(request):
+            data = json.loads(request.content.decode())
+            assert data["messages"][0]["content"] == "hi"
+            return httpx.Response(
+                200,
+                json={
+                    "id": "1",
+                    "model": "qwen",
+                    "choices": [{"message": {"content": "hello"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+                },
+            )
+        respx_mock.post("https://upstream/chat/completions").mock(side_effect=check_request)
+        resp = client.post(
+            "/v1/messages",
+            json={"model": "qwen", "max_tokens": 10, "messages": [{"role": "user", "content": "hi"}]},
+        )
+        body = resp.json()
+        assert body["content"][0]["text"] == "hello"
+        assert body["usage"] == {"input_tokens": 1, "output_tokens": 2}
+
+
+def test_lists_models(client):
+    with respx.mock(assert_all_called=True) as respx_mock:
+        respx_mock.get("https://upstream/models").mock(
+            return_value=httpx.Response(200, json={"data": ["qwen"]})
+        )
+        resp = client.get("/v1/models")
+        assert resp.json() == {"data": ["qwen"]}
+
+
+def test_gets_model_detail(client):
+    with respx.mock(assert_all_called=True) as respx_mock:
+        respx_mock.get("https://upstream/models/qwen").mock(
+            return_value=httpx.Response(200, json={"id": "qwen", "context_length": 8192})
+        )
+        resp = client.get("/v1/models/qwen")
+        assert resp.json()["id"] == "qwen"


### PR DESCRIPTION
## Summary
- add standalone API proxy that reuses Qwen OAuth credentials to forward requests
- map OpenAI completions and Anthropic messages to Qwen API including model information endpoints
- document proxy usage and Qwen interaction accounting with tips to reduce usage
- add server tests covering auth headers, invalid payloads, upstream errors and missing credentials
- add FastAPI implementation with translation helpers and comprehensive tests

## Testing
- `cd packages/api-proxy && npm test`
- `pytest qwenfastapi/tests/test_anthropic.py qwenfastapi/tests/test_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68be8ca4f154833390f7a43c4856d4e4