### PR TITLE
fix: allow host and port in fastapi proxy

### DIFF
--- a/qwenfastapi/README.md
+++ b/qwenfastapi/README.md
@@ -30,3 +30,11 @@ This standalone server exposes Qwen models using both OpenAI `/v1/completions` a
          -d '{"model":"qwen","prompt":"hi"}' \
          http://localhost:3000/v1/completions
     ```
+
+    To inspect available models:
+
+    ```bash
+    curl -H "X-API-Key: $QWEN_FASTAPI_API_KEY" \
+         http://localhost:3000/v1/models
+    ```
+    which returns entries such as `qwen3-coder-plus` and `qwen3-coder-flash`.

--- a/qwenfastapi/README.md
+++ b/qwenfastapi/README.md
@@ -1,6 +1,6 @@
 # Qwen FastAPI Proxy
 
-This standalone server exposes Qwen models using both OpenAI `/v1/completions` and Anthropic `/v1/messages` formats.
+This standalone server exposes Qwen models using OpenAI `/v1/completions` and `/v1/chat/completions` as well as Anthropic `/v1/messages` formats.
 
 ## Usage
 
@@ -11,7 +11,7 @@ This standalone server exposes Qwen models using both OpenAI `/v1/completions` a
     ```
 3. Optional settings:
    - `QWEN_FASTAPI_HOST` — interface and optional port to bind (default `local`, which only allows clients from private or link-local networks such as `10.0.0.0/8`, `100.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `fc00::/7`, and `fe80::/10`; use an explicit IP such as `0.0.0.0` to accept any address). The server listens on port `3000` unless a different port is supplied, e.g. `0.0.0.0:8080`.
-   - `QWEN_FASTAPI_API_KEY` — value clients must provide in the `X-API-Key` header.
+   - `QWEN_FASTAPI_API_KEY` — value clients must provide in the `X-API-Key` header. Local or private network clients are not validated against this key, but public clients must supply the correct value.
    - `QWEN_FASTAPI_CERTFILE` / `QWEN_FASTAPI_KEYFILE` — paths to TLS certificate and private key to enable HTTPS.
    - These can also be supplied on the command line with `--listen`, `--key`, `--certfile` and `--keyfile`.
 4. Start the server:
@@ -30,6 +30,17 @@ This standalone server exposes Qwen models using both OpenAI `/v1/completions` a
          -d '{"model":"qwen","prompt":"hi"}' \
          http://localhost:3000/v1/completions
     ```
+
+    Chat completions use the OpenAI format:
+
+    ```bash
+    curl -H "X-API-Key: $QWEN_FASTAPI_API_KEY" \
+         -H "Content-Type: application/json" \
+         -d '{"messages":[{"role":"user","content":"hi"}]}' \
+         http://localhost:3000/v1/chat/completions
+    ```
+
+    If you omit the `model` field or specify an unsupported model, the proxy falls back to a default such as `qwen3-coder-plus`.
 
     To inspect available models:
 

--- a/qwenfastapi/README.md
+++ b/qwenfastapi/README.md
@@ -10,15 +10,19 @@ This standalone server exposes Qwen models using both OpenAI `/v1/completions` a
     pip install -e qwenfastapi
     ```
 3. Optional settings:
-   - `QWEN_FASTAPI_HOST` — interface to bind (default `local`, which only allows clients from private or link-local networks such as `10.0.0.0/8`, `100.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `fc00::/7`, and `fe80::/10`; use an explicit IP such as `0.0.0.0` to accept any address).
+   - `QWEN_FASTAPI_HOST` — interface and optional port to bind (default `local`, which only allows clients from private or link-local networks such as `10.0.0.0/8`, `100.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `fc00::/7`, and `fe80::/10`; use an explicit IP such as `0.0.0.0` to accept any address). The server listens on port `3000` unless a different port is supplied, e.g. `0.0.0.0:8080`.
    - `QWEN_FASTAPI_API_KEY` — value clients must provide in the `X-API-Key` header.
-   - These can also be supplied on the command line with `--listen` and `--key`.
+   - `QWEN_FASTAPI_CERTFILE` / `QWEN_FASTAPI_KEYFILE` — paths to TLS certificate and private key to enable HTTPS.
+   - These can also be supplied on the command line with `--listen`, `--key`, `--certfile` and `--keyfile`.
 4. Start the server:
     ```bash
     qwenfastapi --help
-    qwenfastapi --listen local --key "$QWEN_FASTAPI_API_KEY"
+    qwenfastapi --listen 0.0.0.0:3000 --key "$QWEN_FASTAPI_API_KEY"
+    # With HTTPS
+    qwenfastapi --listen 0.0.0.0:3000 --certfile cert.pem --keyfile key.pem
     ```
     You can also run `python -m qwenfastapi.main`.
+   The proxy speaks plain HTTP by default; use `http://` URLs unless HTTPS is configured.
 5. Call the proxy:
     ```bash
     curl -H "X-API-Key: $QWEN_FASTAPI_API_KEY" \

--- a/qwenfastapi/tests/test_server.py
+++ b/qwenfastapi/tests/test_server.py
@@ -83,21 +83,15 @@ def test_proxies_messages_and_converts_response(client):
 
 
 def test_lists_models(client):
-    with respx.mock(assert_all_called=True) as respx_mock:
-        respx_mock.get("https://upstream/models").mock(
-            return_value=httpx.Response(200, json={"data": ["qwen"]})
-        )
-        resp = client.get("/v1/models")
-        assert resp.json() == {"data": ["qwen"]}
+    resp = client.get("/v1/models")
+    data = resp.json()["data"]
+    ids = {m["id"] for m in data}
+    assert {"qwen3-coder-plus", "qwen3-coder-flash"} <= ids
 
 
 def test_gets_model_detail(client):
-    with respx.mock(assert_all_called=True) as respx_mock:
-        respx_mock.get("https://upstream/models/qwen").mock(
-            return_value=httpx.Response(200, json={"id": "qwen", "context_length": 8192})
-        )
-        resp = client.get("/v1/models/qwen")
-        assert resp.json()["id"] == "qwen"
+    resp = client.get("/v1/models/qwen3-coder-plus")
+    assert resp.json()["id"] == "qwen3-coder-plus"
 
 def test_rejects_invalid_api_key(monkeypatch):
     monkeypatch.setattr(main, "get_credentials", lambda: ("t", "https://upstream"))


### PR DESCRIPTION
## Summary
- handle host:port syntax in `--listen` and `QWEN_FASTAPI_HOST`
- allow proxy to run over HTTPS via `--certfile`/`--keyfile`
- document HTTP vs HTTPS and expand CLI tests for TLS args

## Testing
- `pytest qwenfastapi -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb501a54083339314b7d9cdbd69b3