### PR TITLE
fix: ensure credentials endpoint has scheme

### DIFF
--- a/qwenfastapi/main.py
+++ b/qwenfastapi/main.py
@@ -81,6 +81,10 @@ def get_credentials() -> tuple[str, str]:
     if not token:
         raise ValueError("No access token")
     endpoint = data.get("resource_url") or DEFAULT_ENDPOINT
+    # Ensure the endpoint contains a scheme. Some credential files provide a bare
+    # host name which httpx rejects because it lacks ``http://`` or ``https://``.
+    if endpoint and not endpoint.startswith(("http://", "https://")):
+        endpoint = f"https://{endpoint}"
     return token, endpoint
 
 

--- a/qwenfastapi/tests/test_server.py
+++ b/qwenfastapi/tests/test_server.py
@@ -269,3 +269,15 @@ def test_is_local_address_ranges():
     # Public addresses should be rejected
     assert not main.is_local_address("8.8.8.8")
     assert not main.is_local_address("2001:4860:4860::8888")
+
+
+def test_get_credentials_adds_https(monkeypatch, tmp_path):
+    creds_dir = tmp_path / ".qwen"
+    creds_dir.mkdir()
+    (creds_dir / "oauth_creds.json").write_text(
+        json.dumps({"access_token": "t", "resource_url": "upstream"})
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    token, endpoint = main.get_credentials()
+    assert token == "t"
+    assert endpoint == "https://upstream"


### PR DESCRIPTION
## Summary
- default to https scheme if resource_url lacks protocol
- test get_credentials handles bare resource_url

## Testing
- `pytest qwenfastapi/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec473aa148333a1da200b9ca21953